### PR TITLE
Add Docker instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ Install dependencies with python 3.10 by running
 bash install.sh
 ```
 or use our [docker image](https://hub.docker.com/layers/qhwang123/researchassistant/latest/images/sha256-6b3690a13ba44fd089086e9860a298ed49a179d9a04a5406c0df074569a3aabe?context=repo). Since agent will modify and execute files, we recommend running experiments within sandboxes such as docker container.
+For docker, use the following instructions: 
+1. Pull the docker image:
+```
+docker pull qhwang123/researchassistant:latest
+```
+2. Run the docker container from the image, mounting the current directory to `/MLAgentBench` inside the container:
+- On Windows PowerShell
+```
+docker run -it -v ${PWD}:/MLAgentBench -w /MLAgentBench qhwang123/researchassistant:latest
+```
+- On Mac or Linux
+```
+docker run -it -v "$(pwd)":/MLAgentBench -w /MLAgentBench qhwang123/researchassistant:latest
+```
 
 Each dataset will be prepared when it is run the first time. You can also prepare them beforehand with 
 ```


### PR DESCRIPTION
Windows users should be using README because some of the functions in the code don't work on Windows (they're Mac or Linux specific). Therefore, having clear instructions for how to get the Docker container going will make set up much faster and proceed as expected