### PR TITLE
fix oom_error and connection_error from throwing an error during eval when log doesn't exist

### DIFF
--- a/MLAgentBench/eval.py
+++ b/MLAgentBench/eval.py
@@ -31,14 +31,20 @@ def oom_error(path):
     log = path.replace("trace.json", "../log")
     main_log = path.replace("trace.json", "../agent_log/main_log")
     message = "CUDA out of memory"
-    return (message in open(log, "r").read()) or (message in open(main_log, "r").read())
+
+    if os.path.exists(log): # sometimes the log file is not created
+        return (message in open(log, "r").read()) or (message in open(main_log, "r").read())
+    return (message in open(main_log, "r").read())
     
 
 def connection_error(path):
     log = path.replace("trace.json", "../log")
     main_log = path.replace("trace.json", "../agent_log/main_log")
     bad = ["You exceeded your current quota, please check your plan and billing details.", "Error: 'text-similarity-ada-001'", "Error: 'text-embedding-ada-001'"]
-    return ("Connection aborted" in open(log, "r").read()) or (any([b in open(main_log, "r").read() for b in bad])) 
+
+    if os.path.exists(log): # sometimes the log file is not created
+        return ("Connection aborted" in open(log, "r").read()) or (any([b in open(main_log, "r").read() for b in bad])) 
+    return (any([b in open(main_log, "r").read() for b in bad])) 
 
 def error(path):
     return os.path.exists(os.path.join(path.replace("trace.json", ""), "error.txt")) or not os.path.exists(os.path.join(path.replace("trace.json", ""), "overall_time.txt"))


### PR DESCRIPTION
**Issue**
_Solution 1_
Addressing the first part of Issue #10: https://github.com/snap-stanford/MLAgentBench/issues/10

Second part of the issue seemed to already be addressed by previous pushes (eval.py in benchmarks/house-price/scripts). However, currently following the "Quick Start" command and running evaluation by running "python -m MLAgentBench.eval --log-folder <log_folder>  --task <task_name> --output-file <output_name>" does not generate a "<log_folder>/log" file for me, as we aren't writing the outputs of the command into the log folder, as it is done here: https://github.com/snap-stanford/MLAgentBench/blob/main/multi_run_experiment.sh#L44

Therefore, this PR is for checking if the log file is generated and exists, before trying to read the log file.

_Solution 2_
Note: The other workaround if the "<log_folder>/log" file is critical is to include in the README.md to update the "Quick Start" command to include a way to capture all the outputs and put it into the "<log_folder>/log" file 

ie. "python -u -m MLAgentBench.runner --python $(which python) --task cifar10 --device 0 --log-dir first_test  --work-dir workspace --llm-name gpt-4 --edit-script-llm-name gpt-4 --fast-llm-name gpt-3.5-turbo **<log_folder>/log 2>&1**"

**Conclusion**
Will close the issue and allow the authors to choose which solution to use. I think that the second solution might be easier and more appropriate because OOM and Connection errors likely won't be caught by the main_log, but it does makes the command to run clunkier. Just one of the solutions need to be adopted though because the current state throws an error when trying to run eval.
